### PR TITLE
Implement easyem CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+embeddings.db
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # easyem
+
+`easyem` is a minimal command line tool for storing text embeddings and searching them.
+It relies on scikit-learn's `HashingVectorizer` to generate embeddings locally and
+a lightweight SQLite database for storage.
+
+## Installation
+
+Ensure Python 3.12+ is available and install dependencies:
+
+```bash
+pip install scikit-learn numpy
+```
+
+## Usage
+
+Store a new text snippet:
+
+```bash
+python -m easyem store "Some text to remember"
+```
+
+Query existing snippets:
+
+```bash
+python -m easyem query "search phrase" --topk 3
+```

--- a/easyem/__init__.py
+++ b/easyem/__init__.py
@@ -1,0 +1,5 @@
+__version__ = '0.1.0'
+
+from .cli import cli
+
+__all__ = ['cli']

--- a/easyem/__main__.py
+++ b/easyem/__main__.py
@@ -1,0 +1,4 @@
+from .cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/easyem/cli.py
+++ b/easyem/cli.py
@@ -1,0 +1,86 @@
+import argparse
+import sqlite3
+import pickle
+from typing import List, Tuple
+
+import numpy as np
+from sklearn.feature_extraction.text import HashingVectorizer
+
+DB_PATH = "embeddings.db"
+
+
+class EasyEm:
+    def __init__(self, db_path: str = DB_PATH, n_features: int = 512):
+        self.db_path = db_path
+        self.vectorizer = HashingVectorizer(n_features=n_features, alternate_sign=False, norm=None)
+        self._ensure_db()
+
+    def _ensure_db(self) -> None:
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS embeddings (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                text TEXT NOT NULL,
+                embedding BLOB NOT NULL
+            )
+            """
+        )
+        conn.commit()
+        conn.close()
+
+    def _embed(self, text: str) -> np.ndarray:
+        vec = self.vectorizer.transform([text]).toarray()[0]
+        return vec.astype(np.float32)
+
+    def store(self, text: str) -> None:
+        embedding = self._embed(text)
+        conn = sqlite3.connect(self.db_path)
+        conn.execute(
+            "INSERT INTO embeddings (text, embedding) VALUES (?, ?)",
+            (text, pickle.dumps(embedding)),
+        )
+        conn.commit()
+        conn.close()
+
+    def query(self, query: str, topk: int = 5) -> List[Tuple[float, int, str]]:
+        q_vec = self._embed(query)
+        q_norm = np.linalg.norm(q_vec)
+        conn = sqlite3.connect(self.db_path)
+        rows = conn.execute("SELECT id, text, embedding FROM embeddings").fetchall()
+        conn.close()
+
+        results = []
+        for row in rows:
+            emb = pickle.loads(row[2])
+            score = float(np.dot(q_vec, emb) / (q_norm * np.linalg.norm(emb)))
+            results.append((score, row[0], row[1]))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return results[:topk]
+
+
+def cli(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="easyem", description="Minimal embedding CLI")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    store_p = subparsers.add_parser("store", help="Store a text blob")
+    store_p.add_argument("text", help="Text to embed and store")
+
+    query_p = subparsers.add_parser("query", help="Query stored texts")
+    query_p.add_argument("text", help="Search query")
+    query_p.add_argument("--topk", type=int, default=5, help="Number of results")
+
+    args = parser.parse_args(argv)
+    app = EasyEm()
+
+    if args.command == "store":
+        app.store(args.text)
+        print("stored")
+    elif args.command == "query":
+        results = app.query(args.text, args.topk)
+        for score, idx, text in results:
+            print(f"{score:.3f}\t{idx}\t{text}")
+
+
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
## Summary
- add a simple CLI package `easyem` with store and query commands
- use scikit-learn HashingVectorizer for embeddings
- save embeddings to SQLite
- document usage in the README
- ignore generated database files

## Testing
- `python -m easyem store "hello world"`
- `python -m easyem query "world" --topk 2`
- `python -m easyem store "Lorem ipsum"`
- `python -m easyem query "ipsum" --topk 2`


------
https://chatgpt.com/codex/tasks/task_e_686e724263e8832db48469897b1e1a3c