### PR TITLE
Add basic embedding CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # easyem
+
+A minimal CLI tool for storing text embeddings and querying them semantically.
+
+## Usage
+
+Build the binary:
+
+```
+go build
+```
+
+Store a piece of text:
+
+```
+./easyem store "some text to remember"
+```
+
+Query the store:
+
+```
+./easyem query "search text" --topk 5
+```
+
+Embeddings are saved to `~/.easyem.gob`.

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module easyem
+
+go 1.23.8

--- a/main.go
+++ b/main.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"hash/fnv"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type Record struct {
+	ID   int
+	Text string
+	Vec  []float64
+}
+
+type Store struct {
+	Records []Record
+	nextID  int
+}
+
+func (s *Store) Add(text string) error {
+	vec := embed(text)
+	s.Records = append(s.Records, Record{ID: s.nextID, Text: text, Vec: vec})
+	s.nextID++
+	return nil
+}
+
+func (s *Store) Query(text string, topk int) ([]Record, error) {
+	if len(s.Records) == 0 {
+		return nil, errors.New("empty store")
+	}
+	q := embed(text)
+	type pair struct {
+		rec   Record
+		score float64
+	}
+	pairs := make([]pair, 0, len(s.Records))
+	for _, r := range s.Records {
+		score := cosine(q, r.Vec)
+		pairs = append(pairs, pair{r, score})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].score > pairs[j].score })
+	if topk > len(pairs) {
+		topk = len(pairs)
+	}
+	results := make([]Record, topk)
+	for i := 0; i < topk; i++ {
+		results[i] = pairs[i].rec
+	}
+	return results, nil
+}
+
+func (s *Store) Save(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := gob.NewEncoder(f)
+	return enc.Encode(s)
+}
+
+func LoadStore(path string) (*Store, error) {
+	s := &Store{}
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return &Store{}, nil
+		}
+		return nil, err
+	}
+	defer f.Close()
+	dec := gob.NewDecoder(f)
+	if err := dec.Decode(s); err != nil {
+		return nil, err
+	}
+	return s, nil
+}
+
+func embed(text string) []float64 {
+	const dim = 100
+	vec := make([]float64, dim)
+	words := strings.Fields(strings.ToLower(text))
+	for _, w := range words {
+		h := fnv.New32a()
+		h.Write([]byte(w))
+		idx := int(h.Sum32() % dim)
+		vec[idx] += 1
+	}
+	norm := 0.0
+	for _, v := range vec {
+		norm += v * v
+	}
+	norm = math.Sqrt(norm)
+	if norm > 0 {
+		for i, v := range vec {
+			vec[i] = v / norm
+		}
+	}
+	return vec
+}
+
+func cosine(a, b []float64) float64 {
+	if len(a) != len(b) {
+		return 0
+	}
+	dot := 0.0
+	for i := range a {
+		dot += a[i] * b[i]
+	}
+	if dot < 0 {
+		return 0
+	}
+	return dot
+}
+
+func usage() {
+	fmt.Println("Usage: easyem <store|query> <text> [--topk K]")
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		usage()
+		return
+	}
+	cmd := os.Args[1]
+	text := strings.Join(os.Args[2:], " ")
+
+	home, _ := os.UserHomeDir()
+	path := filepath.Join(home, ".easyem.gob")
+	store, err := LoadStore(path)
+	if err != nil {
+		fmt.Println("error loading store:", err)
+		return
+	}
+
+	switch cmd {
+	case "store":
+		if err := store.Add(text); err != nil {
+			fmt.Println("error storing text:", err)
+			return
+		}
+		if err := store.Save(path); err != nil {
+			fmt.Println("error saving store:", err)
+			return
+		}
+		fmt.Println("stored text with id", store.nextID-1)
+	case "query":
+		topk := 3
+		for i, arg := range os.Args {
+			if arg == "--topk" && i+1 < len(os.Args) {
+				fmt.Sscanf(os.Args[i+1], "%d", &topk)
+			}
+		}
+		results, err := store.Query(text, topk)
+		if err != nil {
+			fmt.Println("query error:", err)
+			return
+		}
+		for _, r := range results {
+			fmt.Printf("id %d: %s\n", r.ID, r.Text)
+		}
+	default:
+		usage()
+	}
+}


### PR DESCRIPTION
## Summary
- implement a small command line tool in Go
- embed text using a hashed bag‑of‑words
- save embeddings to `~/.easyem.gob`
- provide query capability with top-k results
- document usage in the README

## Testing
- `go build`
- `./easyem store "hello world"`
- `./easyem query "hello" --topk 1`


------
https://chatgpt.com/codex/tasks/task_e_686e81776e6c832d8f37485e4741db84